### PR TITLE
The logo-url in readme fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A react native app for logging glucose, events and carbs. Food database.
 
 Version 1.1
 
-<img src="https://github.com/hanssonfredrik/diabetesninja/blob/master/logo-text.jpg" alt="DiabetesNinja-Logo" width="200px">
+<img src="http://diabetesninja.se/Content/Images/DiabetesNinja_Logo.jpg" alt="DiabetesNinja-Logo" width="200px">
 
 
 ## Getting Started


### PR DESCRIPTION
It seems that the logo only worked for "logged in"-users, changed the URL so that it was re-direceted to the homepage of the app.